### PR TITLE
Switch to using calendar versioning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,6 +4,8 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import datetime
+
 master_doc = 'index'
 
 # -- Path setup --------------------------------------------------------------
@@ -24,7 +26,8 @@ copyright = '2021, Jose Munoz'
 author = 'Jose Munoz'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+calver_scheme = "%Y.%m.%d"
+release = datetime.datetime.utcnow().strftime(calver_scheme)
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This PR switches from a semantic versioning scheme, to a calendar versioning scheme, using `YYYY.0M.0D`, (see <https://calver.org/>).